### PR TITLE
fix table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The selection of algorithms is inspired by the Stanford course [Introduction to 
     - [Gamma encoding](#gamma-encoding)
   - [Search engine](#search-engine)
     - [Search(operator = "AND"):](#searchoperator--and)
-    - [Search(operator = "AND"):](#searchoperator--and-1)
+    - [Search(operator = "OR"):](#searchoperator--or)
     - [Search_n_of_m():](#search_n_of_m)
   - [Ranker](#ranker)
     - [Query evaluation](#query-evaluation)


### PR DESCRIPTION
Fixed a critical bug introduced by #1 

Before this PR you could not navigate to "Search(operator = "OR"):"

Now you can.